### PR TITLE
Install and configure IdentityServer4, the server and the client.

### DIFF
--- a/Controllers/IdentityController.cs
+++ b/Controllers/IdentityController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace NetCoreContactMgrApi
+{
+    /// <summary>
+    /// Part of identity client (API)
+    /// </summary>
+    [Route("identity")]
+    [Authorize]
+    public class IdentityController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Get()
+        {
+            var claimList = from claim in User.Claims
+                            select new { claim.Type, claim.Value };
+            return new JsonResult(claimList);
+        }
+    }
+}

--- a/IdentityServerConfig.cs
+++ b/IdentityServerConfig.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using IdentityServer4.Models;
+
+namespace NetCoreContactMgrApi
+{
+    /// <summary>
+    /// Part of identity server
+    /// </summary>
+    public static class IdentityServerConfig
+    {
+        public static IEnumerable<ApiResource> GetApiResources()
+        {
+            return new List<ApiResource>()
+            {
+                new ApiResource("api1", "My API")
+            };
+        }
+
+        public static IEnumerable<Client> GetClients()
+        {
+            var secret = new Secret("contact-mgr-secret".Sha256());
+            var client = new Client()
+            {
+                ClientId = "contact-mgr-client",
+
+                // no interactive user, use clientId/secret for authentication
+                AllowedGrantTypes = GrantTypes.ClientCredentials,
+
+                // secret for authentication
+                ClientSecrets = { secret },
+
+                // scopes that client has access to
+                AllowedScopes = { "api1" },
+
+                AllowedCorsOrigins = { "http://localhost:9000" }
+            };
+
+            return new List<Client>() { client };
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -42,6 +42,12 @@ namespace NetCoreContactMgrApi
                 });
             });
 
+            // IdentityServer4 service, Part of identiy server
+            services.AddIdentityServer()
+                .AddTemporarySigningCredential()
+                .AddInMemoryApiResources(IdentityServerConfig.GetApiResources())
+                .AddInMemoryClients(IdentityServerConfig.GetClients());
+
             // Add framework services.
             services.AddMvc();
         }
@@ -49,6 +55,12 @@ namespace NetCoreContactMgrApi
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
+            // IdentityServer4: Part of identiy server 
+            loggerFactory.AddConsole(LogLevel.Debug);
+            app.UseDeveloperExceptionPage();
+
+            app.UseIdentityServer();
+
             // Enable CORS to all controllers
             // need to put at the most top because this is sending headers.
             if (env.IsDevelopment())
@@ -63,6 +75,17 @@ namespace NetCoreContactMgrApi
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
+            // part of identity client (the API)
+            app.UseIdentityServerAuthentication(new IdentityServerAuthenticationOptions()
+            {
+                // For this code, the identity server and the API is in the same server.
+                // API server baseurl isn't defined thus using default baseUrl localhost:5000
+                Authority = "http://localhost:5000",
+                RequireHttpsMetadata = false,
+
+                ApiName = "api1"
+            });
+            
             app.UseMvc();
         }
     }

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,9 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="local" value="lib" />
   </packageSources>
 </configuration>

--- a/project.json
+++ b/project.json
@@ -18,7 +18,12 @@
         "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0",
         "Newtonsoft.Json": "9.0.1",
         "Microsoft.AspNetCore.Cors": "1.1.0",
-        "bowozer.latihan.moja": "1.0.0"
+        "bowozer.latihan.moja": "1.0.0",
+        "Microsoft.AspNetCore.Diagnostics": "1.1.0",
+        // part of identity server
+        "IdentityServer4": "1.0.0",
+        // part of identity client (API)
+        "IdentityServer4.AccessTokenValidation": "1.0.5"
     },
 
     "tools": {


### PR DESCRIPTION
Turns out with IdentityServer4 we can have authentication server different
with the API server.

In this example, the authentication is just OAuth2 client_credentials. But
it isn't impossible to use OAuth2 password.

Also CORS is allowed for IdentityServer4. CORS for WebApi doesn't take
effect on the IdentityServer4.